### PR TITLE
Issue #682

### DIFF
--- a/app/src/main/java/org/digitalcampus/oppia/activity/CourseIndexActivity.java
+++ b/app/src/main/java/org/digitalcampus/oppia/activity/CourseIndexActivity.java
@@ -17,15 +17,26 @@
 
 package org.digitalcampus.oppia.activity;
 
-import java.util.ArrayList;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.Callable;
+import android.animation.ValueAnimator;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.graphics.drawable.BitmapDrawable;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.v4.view.ViewCompat;
+import android.support.v7.app.AlertDialog;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.animation.AlphaAnimation;
+import android.widget.ListView;
 
 import org.digitalcampus.mobile.learning.R;
 import org.digitalcampus.oppia.adapter.SectionListAdapter;
 import org.digitalcampus.oppia.application.MobileLearning;
-import org.digitalcampus.oppia.exception.InvalidXMLException;
 import org.digitalcampus.oppia.model.Activity;
 import org.digitalcampus.oppia.model.CompleteCourse;
 import org.digitalcampus.oppia.model.CompleteCourseProvider;
@@ -37,28 +48,11 @@ import org.digitalcampus.oppia.service.TrackerService;
 import org.digitalcampus.oppia.task.ParseCourseXMLTask;
 import org.digitalcampus.oppia.utils.ImageUtils;
 import org.digitalcampus.oppia.utils.UIUtils;
-import org.digitalcampus.oppia.utils.xmlreaders.CourseXMLReader;
 
-import android.animation.ValueAnimator;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
-import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
-import android.graphics.drawable.BitmapDrawable;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.support.design.widget.FloatingActionButton;
-import android.support.v4.view.ViewCompat;
-import android.support.v7.app.AlertDialog;
-import android.support.v7.widget.Toolbar;
-import android.view.Menu;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.animation.AlphaAnimation;
-import android.widget.ImageView;
-import android.widget.ListView;
-import android.widget.TextView;
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
@@ -413,6 +407,7 @@ public class CourseIndexActivity extends AppActivity implements OnSharedPreferen
     public void onParseComplete(CompleteCourse parsed) {
         parsedCourse = parsed;
         course.setMetaPages(parsedCourse.getMetaPages());
+        course.setMedia(parsedCourse.getMedia());
         sections = parsedCourse.getSections();
 
         boolean baselineCompleted = isBaselineCompleted();

--- a/app/src/main/java/org/digitalcampus/oppia/utils/mediaplayer/VideoPlayerActivity.java
+++ b/app/src/main/java/org/digitalcampus/oppia/utils/mediaplayer/VideoPlayerActivity.java
@@ -120,9 +120,11 @@ public class VideoPlayerActivity extends AppActivity implements SurfaceHolder.Ca
 		// track that the video has been played (or at least clicked on)
 		Tracker t = new Tracker(this);
 		// digest should be that of the video not the page
+        Log.d(TAG, "Attempting to save media tracker. Time: " + timeTaken);
 		for (Media m : this.activity.getMedia()) {
+		    Log.d(TAG, mediaFileName + "/" + m.getFilename());
 			if (m.getFilename().equals(mediaFileName)) {
-				Log.d(TAG,"saving tracker...");
+				Log.d(TAG,"saving tracker... " + m.getLength());
 				boolean completed = false;
 				if (timeTaken >= m.getLength()) {
 					completed = true;

--- a/app/src/main/java/org/digitalcampus/oppia/widgets/PageWidget.java
+++ b/app/src/main/java/org/digitalcampus/oppia/widgets/PageWidget.java
@@ -17,13 +17,17 @@
 
 package org.digitalcampus.oppia.widgets;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Locale;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.LinearLayout.LayoutParams;
 
 import org.digitalcampus.mobile.learning.R;
 import org.digitalcampus.oppia.activity.CourseActivity;
@@ -36,26 +40,18 @@ import org.digitalcampus.oppia.model.Activity;
 import org.digitalcampus.oppia.model.Course;
 import org.digitalcampus.oppia.model.Media;
 import org.digitalcampus.oppia.utils.MetaDataUtils;
-import org.digitalcampus.oppia.utils.mediaplayer.VideoPlayerActivity;
 import org.digitalcampus.oppia.utils.resources.JSInterfaceForResourceImages;
 import org.digitalcampus.oppia.utils.storage.FileUtils;
-import org.digitalcampus.oppia.utils.storage.Storage;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import android.content.ActivityNotFoundException;
-import android.content.Intent;
-import android.net.Uri;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.webkit.WebView;
-import android.webkit.WebViewClient;
-import android.widget.LinearLayout.LayoutParams;
-import android.widget.Toast;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
 
 public class PageWidget extends WidgetFactory {
 


### PR DESCRIPTION
The problem with the media trackers in #682 was related with the course parsing. The media for an activity was not being set correctly, so after a video was played, as the media was not related with the current activity the tracker was not being created.